### PR TITLE
Refactor: move Monday logic into a factory function

### DIFF
--- a/.github/scripts/mondayRemoveLabel.js
+++ b/.github/scripts/mondayRemoveLabel.js
@@ -1,7 +1,6 @@
 // @ts-check
 const Monday = require("./support/monday.js");
 const {
-  mondayBoard,
   mondayLabels,
   resources: {
     labels: {

--- a/.github/scripts/mondayRemoveLabel.js
+++ b/.github/scripts/mondayRemoveLabel.js
@@ -17,12 +17,12 @@ module.exports = async ({ context }) => {
       context.payload
     );
   const labelName = label?.name;
-  const monday = Monday(issue);
-
   if (!labelName) {
     console.log("No label found in the payload.");
     process.exit(0);
   }
+
+  const monday = Monday(issue);
 
   const isSpike = labelName === spike;
   if (isSpike && issue.labels) {

--- a/.github/scripts/mondayUpdateAssignee.js
+++ b/.github/scripts/mondayUpdateAssignee.js
@@ -1,10 +1,6 @@
 // @ts-check
-const {
-  updateMultipleColumns,
-  notInLifecycle,
-  assignLabel,
-  updateAssignees,
-} = require("./support/utils");
+const { notInLifecycle } = require("./support/utils");
+const Monday = require("./support/monday.js");
 const {
   resources: {
     labels: {
@@ -15,21 +11,21 @@ const {
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
-  const { MONDAY_KEY } = process.env;
   const {
-    issue: { number, body, assignees: currentAssignees, labels },
+    issue,
     assignee: newAssignee,
     action,
   } = /** @type {import('@octokit/webhooks-types').IssuesAssignedEvent | import('@octokit/webhooks-types').IssuesUnassignedEvent } */ (
-    context.payload
-  );
+      context.payload
+    );
+  const { assignees: currentAssignees, labels } = issue;
+  const monday = Monday(issue);
 
   if (!newAssignee) {
-    console.log(`No new assignee found for issue #${number}.`);
+    console.log(`No new assignee found, exiting.`);
     process.exit(0);
   }
 
-  let valueObject = {};
   // Unassigned action, no assignees left, not in lifecycle:
   // Set status to "Unassigned", no assignee updates
   if (
@@ -37,8 +33,7 @@ module.exports = async ({ context }) => {
     currentAssignees.length === 0 &&
     notInLifecycle(labels)
   ) {
-    valueObject = assignLabel(newLabel, valueObject);
-
+    monday.addLabel(newLabel);
     console.info("Set status to unassigned, no assignees updated");
   }
   // Assigned action, not in lifecycle besides "needs milestone":
@@ -47,26 +42,13 @@ module.exports = async ({ context }) => {
     action === "assigned" &&
     notInLifecycle(labels, { skipMilestone: true })
   ) {
-    valueObject = assignLabel(assignedLabel, valueObject);
-    valueObject = updateAssignees(currentAssignees, valueObject);
-
+    monday.addLabel(assignedLabel);
+    monday.addAllAssignees();
     console.info("Update assignees, set status to assigned");
   } else if (currentAssignees.length > 0) {
-    valueObject = updateAssignees(currentAssignees, valueObject);
-
+    monday.addAllAssignees();
     console.info("Update assignees, no status change");
   }
 
-  if (!Object.keys(valueObject).length) {
-    console.info("No updates to assignees or status.");
-    process.exit(0);
-  }
-
-  try {
-    await updateMultipleColumns(MONDAY_KEY, body, number, valueObject);
-    process.exit(0);
-  } catch (error) {
-    console.log(`Error updating assignee values in Monday.com: ${error}`);
-    process.exit(1);
-  }
+  await monday.commitChanges();
 };

--- a/.github/scripts/mondayUpdateLabels.js
+++ b/.github/scripts/mondayUpdateLabels.js
@@ -1,51 +1,20 @@
 // @ts-check
-const {
-  resources: {
-    labels: {
-      issueWorkflow: { needsMilestone, readyForDev },
-    },
-  },
-} = require("./support/resources");
-const {
-  notReadyForDev,
-  assignLabel,
-  updateMultipleColumns,
-} = require("./support/utils");
+const Monday = require("./support/monday.js");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
-  const { MONDAY_KEY } = process.env;
   const { issue, label } =
     /** @type {import('@octokit/webhooks-types').IssuesLabeledEvent} */ (
       context.payload
     );
   const labelName = label?.name;
+  const monday = Monday(issue);
 
   if (!labelName) {
     console.log("No label found in the payload.");
     process.exit(0);
   }
 
-  // Skip "needs milestone" if "ready for dev" is applied
-  if (labelName === needsMilestone && !notReadyForDev(issue.labels)) {
-    console.log(
-      `Skipping '${needsMilestone}' label as '${readyForDev}' is already applied.`,
-    );
-    process.exit(0);
-  }
-
-  try {
-    await updateMultipleColumns(
-      MONDAY_KEY,
-      issue.body,
-      issue.number,
-      assignLabel(labelName, {}),
-    );
-    process.exit(0);
-  } catch (error) {
-    console.log(
-      `Error updating Monday.com task with label '${labelName}': ${error}`,
-    );
-    process.exit(1);
-  }
+  monday.addLabel(labelName);
+  await monday.commitChanges();
 };

--- a/.github/scripts/mondayUpdateMilestone.js
+++ b/.github/scripts/mondayUpdateMilestone.js
@@ -1,32 +1,14 @@
 // @ts-check
-const { handleMilestone, updateMultipleColumns } = require("./support/utils");
+const Monday = require("./support/monday.js");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
-  const { MONDAY_KEY } = process.env;
-  const {
-    issue: { body, number, milestone, assignee, labels },
-  } = /** @type {import('@octokit/webhooks-types').IssuesMilestonedEvent} */ (
-    context.payload
-  );
+  const { issue } =
+    /** @type {import('@octokit/webhooks-types').IssuesMilestonedEvent} */ (
+      context.payload
+    );
+  const monday = Monday(issue);
 
-  const columnUpdates = handleMilestone(milestone, assignee, labels);
-
-  if (columnUpdates.length === 0) {
-    console.log("No columns to update for the milestone event.");
-    process.exit(0);
-  }
-
-  const valuesObject = {};
-  columnUpdates.forEach((value) => {
-    valuesObject[value.column] = value.value;
-  });
-
-  try {
-    await updateMultipleColumns(MONDAY_KEY, body, number, valuesObject);
-    process.exit(0);
-  } catch (error) {
-    console.log(`Error updating Milestone values in Monday.com: ${error}`);
-    process.exit(1);
-  }
+  monday.handleMilestone();
+  await monday.commitChanges();
 };

--- a/.github/scripts/mondayUpdateState.js
+++ b/.github/scripts/mondayUpdateState.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { updateMultipleColumns } = require("./support/utils");
+const Monday = require("./support/monday.js");
 const {
   mondayColumns,
   resources: {
@@ -11,37 +11,28 @@ const {
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
-  const { MONDAY_KEY } = process.env;
-  const {
-    issue: { number, body, labels, state_reason },
-    action,
-  } =
+  const { issue, action } =
     /** @type {import('@octokit/webhooks-types').IssuesClosedEvent | import('@octokit/webhooks-types').IssuesReopenedEvent}*/ (
       context.payload
     );
-
-  const valueObject = {
-    [mondayColumns.open]: "Closed",
-  };
+  const monday = Monday(issue);
 
   if (action === "reopened") {
-    valueObject[mondayColumns.open] = "Open";
+    monday.setColumnValue(mondayColumns.open, "Open");
   } else {
+    monday.setColumnValue(mondayColumns.open, "Closed");
     // If closed but not completed, set status to "Closed"
-    if (state_reason !== "completed") {
-      valueObject[mondayColumns.status] = "Closed";
+    if (issue.state_reason !== "completed") {
+      monday.setColumnValue(mondayColumns.status, "Closed");
     }
     // If not a design issue, set status to "Done"
-    else if (labels && labels.every((label) => label.name !== design)) {
-      valueObject[mondayColumns.status] = "Done";
+    else if (
+      issue.labels &&
+      issue.labels.every((label) => label.name !== design)
+    ) {
+      monday.setColumnValue(mondayColumns.status, "Done");
     }
   }
 
-  try {
-    await updateMultipleColumns(MONDAY_KEY, body, number, valueObject);
-    process.exit(0);
-  } catch (error) {
-    console.log(`Error updating Monday.com task: ${error}`);
-    process.exit(1);
-  }
+  await monday.commitChanges();
 };

--- a/.github/scripts/mondayUpdateTitle.js
+++ b/.github/scripts/mondayUpdateTitle.js
@@ -1,27 +1,20 @@
 // @ts-check
-const { updateMultipleColumns } = require("./support/utils");
+const Monday = require("./support/monday.js");
 const { mondayColumns } = require("./support/resources");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
-  const { MONDAY_KEY } = process.env;
   const { issue, changes } =
     /** @type {import('@octokit/webhooks-types').IssuesEditedEvent} */ (
       context.payload
     );
-  
-  if(!changes.title) {
+  const monday = Monday(issue);
+
+  if (!changes.title) {
     console.log("No title change detected in the payload.");
     process.exit(0);
   }
 
-  const valueObject = { [mondayColumns.title]: issue.title }
-
-  try {
-    await updateMultipleColumns(MONDAY_KEY, issue.body, issue.number, valueObject);
-    process.exit(0);
-  } catch (error) {
-    console.log(`Error updating Monday.com task title: ${error}`);
-    process.exit(1);
-  }
-}
+  monday.setColumnValue(mondayColumns.title, issue.title);
+  await monday.commitChanges();
+};

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -386,9 +386,9 @@ module.exports = function Monday(issue) {
   /**
    * Clear a column value in columnUpdates based on the label
    * @param {string} label - The label name to clear
-   * @returns {Promise<void>}
+   * @returns {void}
    */
-  async function clearLabel(label) {
+  function clearLabel(label) {
     const labelColumn = mondayLabels.get(label)?.column;
     if (!labelColumn) {
       console.warn(`Label ${label} not found in Monday Labels map`);

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -1,0 +1,426 @@
+// @ts-check
+const {
+  mondayBoard,
+  mondayColumns,
+  mondayLabels,
+  mondayPeople,
+  resources,
+} = require("./resources");
+const { notReadyForDev, notInLifecycle } = require("./utils");
+
+/**
+ * @param {import('@octokit/webhooks-types').Issue} issue - The GitHub issue object
+ */
+module.exports = function Monday(issue) {
+  const { MONDAY_KEY } = process.env;
+  console.log(
+    MONDAY_KEY
+      ? "Monday.com API key is set."
+      : "Monday.com API key is NOT set.",
+  );
+
+  if (!MONDAY_KEY) {
+    console.log("Monday.com API key is not set.");
+    process.exit(1);
+  }
+  if (!issue) {
+    console.log("No GitHub issue provided.");
+    process.exit(1);
+  }
+
+  const {
+    title,
+    body,
+    number: issueNumber,
+    milestone,
+    labels,
+    assignee,
+    assignees,
+    html_url,
+  } = issue;
+
+  let columnUpdates = {};
+
+  /** Private helper functions */
+
+  /**
+   * Formats the values object for use in Monday.com API calls
+   * @private
+   * @param {object} values - The values object to format
+   * @return {string} - The formatted values string
+   */
+  function formatValues(values) {
+    return JSON.stringify(values).replace(/"/g, '\\"');
+  }
+  /**
+   * Assigns a person to columnUpdates based on their GitHub username/role
+   * @private
+   * @param {import('@octokit/webhooks-types').User} person
+   */
+  function addAssignee(person) {
+    if (!person?.login) {
+      console.warn("No person or login provided for assignment");
+      return;
+    }
+
+    const info = mondayPeople.get(person.login);
+    if (!info) {
+      console.warn(`Assignee ${person.login} not found in peopleMap`);
+      return;
+    }
+
+    if (columnUpdates[info.role]) {
+      columnUpdates[info.role] += `, ${info.id}`;
+    } else {
+      columnUpdates[info.role] = `${info.id}`;
+    }
+  }
+  /**
+   * Calls the Monday.com API with a provided query
+   * @private
+   * @param {string} query - The GraphQL query string
+   * @returns {Promise<string | undefined>}
+   */
+  async function runQuery(query) {
+    // Double-check as TS doesn't seem to narrow based on the outer function check
+    if (!MONDAY_KEY) {
+      throw new Error("Monday.com API key is not set.");
+    }
+
+    try {
+      const response = await fetch("https://api.monday.com/v2", {
+        method: "post",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: MONDAY_KEY,
+        },
+        body: JSON.stringify({
+          query: query,
+        }),
+      });
+
+      const body = await response.json();
+
+      if (!response.ok) {
+        throw new Error(
+          `HTTP error when calling the Monday API: ${JSON.stringify(body)}`,
+        );
+      }
+
+      return body;
+    } catch (error) {
+      throw new Error(`Error calling Monday.com API: ${error}`);
+    }
+  }
+  /**
+   * Creates and runs a query to update columns in a Monday.com item
+   * @private
+   * @param {object} values - The values to update in the item
+   * @returns {Promise<string | undefined>} - The ID of the updated Monday.com item
+   */
+  async function updateMultipleColumns(values) {
+    const mondayID = await getId();
+    if (!mondayID) {
+      throw new Error(`No Monday ID found for GitHub issue #${issueNumber}`);
+    }
+
+    const query = `mutation { 
+      change_multiple_column_values(
+        board_id: ${mondayBoard},
+        item_id: ${mondayID},
+        column_values: "${formatValues(values)}"
+      ) {
+        id
+      }
+    }`;
+
+    const response = await runQuery(query);
+    if (
+      !response ||
+      !response["data"] ||
+      !response["data"]["change_multiple_column_values"]
+    ) {
+      console.log(query, response);
+      throw new Error(`Failed to update columns for item ID ${mondayID}`);
+    }
+
+    return response["data"]["change_multiple_column_values"]["id"];
+  }
+
+  /** Public functions */
+
+  /**
+   * Return the Monday.com item ID for a issue.
+   * ID is parsed from the issue body or fetched based on the issue number
+   * @return {Promise<string>} - The Monday.com item ID
+   */
+  async function getId() {
+    const mondayRegex = /(?<=\*\*monday\.com sync:\*\* #)(\d+)/;
+    const mondayRegexMatch = body?.match(mondayRegex);
+    let mondayID =
+      mondayRegexMatch && mondayRegexMatch[0] ? mondayRegexMatch[0] : "";
+
+    if (!mondayID) {
+      const query = `query {
+        items_page_by_column_values(
+          board_id: "${mondayBoard}",
+          columns: {
+            column_id: "${mondayColumns.issueNumber}",
+            column_values: ["${issueNumber}"]
+          },
+        ) {
+          items {
+            id
+          }
+        }
+      }`;
+
+      const response = await runQuery(query);
+
+      if (!response) {
+        throw new Error(`No response for Github Issue #${issueNumber}`);
+      }
+
+      const items = response["data"]["items_page_by_column_values"]["items"];
+
+      if (!items?.length) {
+        console.warn(`No items found for Github Issue #${issueNumber}`);
+        return "";
+      }
+
+      mondayID = items[0]["id"];
+    }
+
+    return mondayID;
+  }
+  /**
+   * Commit any pending column updates to Monday.com
+   */
+  async function commitChanges() {
+    if (Object.keys(columnUpdates).length === 0) {
+      console.log("No column updates to commit.");
+      return;
+    }
+
+    await updateMultipleColumns(columnUpdates);
+    columnUpdates = {};
+  }
+  /**
+   * Create a new task in Monday.com
+   * @returns {Promise<string>} - The ID of the created Monday.com item
+   */
+  async function createTask() {
+    /** @type {Record<string, string | number | object>} */
+    columnUpdates = {
+      [mondayColumns.issueNumber]: `${issueNumber}`,
+      [mondayColumns.link]: {
+        url: html_url,
+        text: `${issueNumber}`,
+      },
+    };
+
+    // Add labels if present
+    if (labels?.length) {
+      labels.forEach((label) => addLabel(label.name));
+    }
+    // If no lifecycle label: set default status
+    if (notInLifecycle(labels)) {
+      const needsTriage = mondayLabels.get(
+        resources.labels.issueWorkflow.needsTriage,
+      );
+      if (needsTriage) {
+        columnUpdates[needsTriage.column] = needsTriage.value;
+      }
+    }
+
+    // Add assignees if present
+    if (assignees.length) {
+      assignees.forEach((person) => addAssignee(person));
+
+      // Set to "assigned" if no lifecycle labels were applied
+      // Overrides the default "needs triage" label
+      if (notInLifecycle(labels)) {
+        const assigned = mondayLabels.get(
+          resources.labels.issueWorkflow.assigned,
+        );
+        if (assigned) {
+          columnUpdates[assigned.column] = assigned.value;
+        }
+      }
+    }
+
+    // Handle milestone if present
+    if (milestone) {
+      handleMilestone();
+    }
+
+    const query = `mutation { 
+      create_item (
+        board_id: ${mondayBoard},
+        item_name: "${title}",
+        column_values: "${formatValues(columnUpdates)}"
+      ) {
+        id
+      }
+    }`;
+
+    const response = await runQuery(query);
+    if (
+      !response ||
+      !response["data"] ||
+      !response["data"]["create_item"]["id"]
+    ) {
+      throw new Error(`Failed to create item for issue #${issueNumber}`);
+    }
+
+    return response["data"]["create_item"]["id"];
+  }
+  /**
+   * Set a specific column value in columnUpdates
+   * @param {string} column - The column ID to set
+   * @param {string | number | object} value - The value to set
+   */
+  function setColumnValue(column, value) {
+    if (!column) {
+      console.warn("No column provided to setColumnValue");
+      return;
+    }
+    if (value === undefined || value === null) {
+      console.warn("No value provided to setColumnValue");
+      return;
+    }
+
+    columnUpdates[column] = value;
+  }
+  /**
+   * Update columnUpdates based on milestone title
+   */
+  function handleMilestone() {
+    const statusMilestones = [
+      resources.milestone.stalled,
+      resources.milestone.backlog,
+      resources.milestone.freezer,
+    ];
+
+    // If removed, reset date
+    if (!milestone) {
+      columnUpdates[mondayColumns.date] = "";
+      return;
+    }
+    const milestoneTitle = milestone.title;
+
+    // Attempt to extract the date from the milestone title
+    const dateRegex = /\d{4}-\d{2}-\d{2}/;
+    const dueDate = milestoneTitle.match(dateRegex);
+
+    if (dueDate) {
+      columnUpdates[mondayColumns.date] = dueDate[0];
+
+      // Assigned and NO lifecycle label - OUTSIDE OF "needs milestone"
+      if (assignee && notInLifecycle(labels, { skipMilestone: true })) {
+        const status = mondayLabels.get(
+          resources.labels.issueWorkflow.assigned,
+        );
+
+        if (status) {
+          columnUpdates[status.column] = status.value;
+        }
+      }
+      // If unassigned and NOT "Ready for Dev"
+      else if (!assignee && notReadyForDev(labels)) {
+        const status = mondayLabels.get(resources.labels.issueWorkflow.new);
+
+        if (status) {
+          columnUpdates[status.column] = status.value;
+        }
+      }
+    } else if (statusMilestones.includes(milestoneTitle)) {
+      columnUpdates[mondayColumns.status] = milestoneTitle;
+      columnUpdates[mondayColumns.date] = "";
+    }
+  }
+  /**
+   * Assign each of the current assignees to columnUpdates.
+   */
+  function addAllAssignees() {
+    assignees.forEach((assignee) => {
+      addAssignee(assignee);
+    });
+  }
+  /**
+   * Add a label to columnUpdates
+   * @param {string} label
+   */
+  function addLabel(label) {
+    // Skip the sync label, as it is not needed in Monday.com
+    if (label === "monday.com sync") {
+      return;
+    }
+
+    // Skip "needs milestone" if "ready for dev" is applied
+    const { needsMilestone, readyForDev } = resources.labels.issueWorkflow;
+    if (label === needsMilestone && !notReadyForDev(labels)) {
+      console.log(
+        `Skipping '${needsMilestone}' label as '${readyForDev}' is already applied.`,
+      );
+      return;
+    }
+
+    if (!mondayLabels.has(label)) {
+      console.warn(`Label ${label} not found in Monday Labels map`);
+      return;
+    }
+
+    const info = mondayLabels.get(label);
+    if (!info?.column || !info?.value) {
+      console.warn(`Label ${label} is missing column or title information`);
+      return;
+    }
+
+    columnUpdates[info.column] = info.value;
+  }
+  /**
+   * Clear a column value in columnUpdates based on the label
+   * @param {string} label - The label name to clear
+   * @returns {Promise<void>}
+   */
+  async function clearLabel(label) {
+    const id = await getId();
+    if (!id) {
+      return;
+    }
+    const labelColumn = mondayLabels.get(label)?.column;
+    if (!labelColumn) {
+      console.warn(`Label ${label} not found in Monday Labels map`);
+      return;
+    }
+    // Clear the label by setting it to an empty string
+    columnUpdates[labelColumn] = "";
+  }
+  /**
+   * Inserts or replaces the Monday sync line in the issue body string
+   * @param {string} mondayID - The Monday.com item ID
+   * @returns {string} - The updated issue body
+   */
+  function addSyncLine(mondayID) {
+    const syncMarkdown = `**monday.com sync:** #${mondayID}\n\n`;
+    const syncLineRegex = /^\*\*monday\.com sync:\*\* #\d+\n\n?/m;
+    if (body && syncLineRegex.test(body)) {
+      return body.replace(syncLineRegex, syncMarkdown);
+    } else {
+      return syncMarkdown + (body || "");
+    }
+  }
+
+  return {
+    getId,
+    commitChanges,
+    createTask,
+    setColumnValue,
+    handleMilestone,
+    addAllAssignees,
+    addLabel,
+    clearLabel,
+    addSyncLine,
+  };
+};

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -77,7 +77,7 @@ module.exports = function Monday(issue) {
    * Calls the Monday.com API with a provided query
    * @private
    * @param {string} query - The GraphQL query string
-   * @returns {Promise<string | undefined>}
+   * @returns {Promise<any>}
    */
   async function runQuery(query) {
     // Double-check as TS doesn't seem to narrow based on the outer function check
@@ -133,17 +133,12 @@ module.exports = function Monday(issue) {
     }`;
 
     const response = await runQuery(query);
-    if (
-      !response ||
-      !response["data"] ||
-      !response["data"]["change_multiple_column_values"] ||
-      !response["data"]["change_multiple_column_values"]["id"]
-    ) {
+    if (!response?.data?.change_multiple_column_values?.id) {
       console.log(query, response);
       throw new Error(`Failed to update columns for item ID ${mondayID}`);
     }
 
-    return response["data"]["change_multiple_column_values"]["id"];
+    return response.data.change_multiple_column_values.id;
   }
   /**
    * Return the Monday.com item ID for a issue.
@@ -205,7 +200,8 @@ module.exports = function Monday(issue) {
       return;
     }
 
-    await updateMultipleColumns(columnUpdates);
+    const id = await updateMultipleColumns(columnUpdates);
+    console.log(`Committed changes to Monday item ID ${id}`);
     columnUpdates = {};
   }
   /**
@@ -268,16 +264,11 @@ module.exports = function Monday(issue) {
     }`;
 
     const response = await runQuery(query);
-    if (
-      !response ||
-      !response["data"] ||
-      !response["data"]["create_item"] ||
-      !response["data"]["create_item"]["id"] 
-    ) {
+    if (!response?.data?.create_item?.id) {
       throw new Error(`Failed to create item for issue #${issueNumber}`);
     }
 
-    return response["data"]["create_item"]["id"];
+    return response.data.create_item.id;
   }
   /**
    * Set a specific column value in columnUpdates

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -20,12 +20,10 @@ module.exports = function Monday(issue) {
   );
 
   if (!MONDAY_KEY) {
-    console.log("Monday.com API key is not set.");
-    process.exit(1);
+    throw new Error("Monday.com API key is not set.");
   }
   if (!issue) {
-    console.log("No GitHub issue provided.");
-    process.exit(1);
+    throw new Error("No GitHub issue provided.");
   }
 
   const {

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -325,7 +325,7 @@ module.exports = function Monday(issue) {
         }
       }
       // If unassigned and NOT "Ready for Dev"
-      else if (!assignee && notReadyForDev(labels)) {
+      if (!assignee && notReadyForDev(labels)) {
         const status = mondayLabels.get(resources.labels.issueWorkflow.new);
 
         if (status) {

--- a/.github/scripts/support/utils.js
+++ b/.github/scripts/support/utils.js
@@ -1,517 +1,105 @@
 // @ts-check
 const {
-  mondayBoard,
-  mondayColumns,
-  mondayLabels,
-  mondayPeople,
-  resources,
+  resources: {
+    labels: { issueWorkflow },
+  },
 } = require("./resources");
 
-/**
- * @typedef {object} removeLabelParam
- * @property {InstanceType<typeof import('@actions/github/lib/utils').GitHub>} github
- * @property {import('@actions/github/lib/context').Context} context
- * @property {string} label
- *
- * @param {removeLabelParam} obj
- **/
-async function removeLabel({ github, context, label }) {
-  const { owner, repo } = context.repo;
-  const issue_number = context.issue.number;
-
-  try {
-    await github.rest.issues.removeLabel({
-      issue_number,
-      owner,
-      repo,
-      name: label,
-    });
-  } catch (err) {
-    if (err.status === 404) {
-      console.log(
-        `The label '${label}' is not associated with issue #${issue_number}.`,
-        err,
-      );
-    } else {
-      console.log("Error while attempting to remove issue label.", err);
-    }
-  }
-}
-
-/**
- * @typedef {object} createLabelIfMissingParam
- * @property {InstanceType<typeof import('@actions/github/lib/utils').GitHub>} github
- * @property {import('@actions/github/lib/context').Context} context
- * @property {string} label
- * @property {string} color
- * @property {string} description
- *
- * @param {createLabelIfMissingParam} obj
- **/
-async function createLabelIfMissing({
-  github,
-  context,
-  label,
-  color,
-  description,
-}) {
-  const { owner, repo } = context.repo;
-  try {
-    await github.rest.issues.getLabel({
-      owner,
-      repo,
-      name: label,
-    });
-  } catch {
-    await github.rest.issues.createLabel({
-      owner,
-      repo,
-      name: label,
-      color,
-      description,
-    });
-  }
-}
-
-/**
- * Calls the Monday.com API with a provided query
- * @param {string | undefined} key - The Monday.com API key
- * @param {string} query - The GraphQL query to execute
- * @returns {Promise<string | undefined>}
- */
-async function callMonday(key, query) {
-  try {
-    if (!key) {
-      throw new Error("Monday.com API key is not set.");
-    }
-
-    const response = await fetch("https://api.monday.com/v2", {
-      method: "post",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: key,
-      },
-      body: JSON.stringify({
-        query: query,
-      }),
-    });
-    console.log(`Query: ${query}`);
-
-    const body = await response.json();
-
-    if (!response.ok) {
-      throw new Error(
-        `HTTP error when calling the Monday API: ${JSON.stringify(body)}`,
-      );
-    }
-
-    return body;
-  } catch (error) {
-    throw new Error(`Error calling Monday.com API: ${error}`);
-  }
-}
-
-/**
- * Returns the Monday.com task ID for the passed GitHub Issue ID.
- * Matches based on the GitHub Issue ID column.
- * @param {string | undefined} key - The Monday.com API key
- * @param {number} githubID
- * @returns {Promise<string>}
- */
-async function fetchMondayID(key, githubID) {
-  const query = `query {
-      items_page_by_column_values(
-        board_id: "${mondayBoard}",
-        columns: {
-          column_id: "${mondayColumns.issueNumber}",
-          column_values: ["${githubID}"]
-        },
-      ) {
-        items {
-          id
-        }
-      }
-    }`;
-
-  const response = await callMonday(key, query);
-
-  if (!response) {
-    throw new Error(`No response for Github Issue #${githubID}`);
-  }
-
-  const items = response["data"]["items_page_by_column_values"]["items"];
-
-  if (!items?.length) {
-    throw new Error(`No items found for Github Issue #${githubID}`);
-  }
-
-  return items[0]["id"];
-}
-
-/**
- * Updates multiple columns in a Monday.com item
- * @param {string | undefined} key - The Monday.com API key
- * @param {string | null} body - The issue body containing the sync line
- * @param {number} githubID - The GitHub issue number
- * @param {object} values - The values to update in the item
- * @returns {Promise<string | undefined>}
- */
-async function updateMultipleColumns(key, body, githubID, values) {
-  const mondayID = await getMondayID(key, body, githubID);
-  if (!mondayID) {
-    throw new Error(`No Monday ID found for GitHub issue #${githubID}`);
-  }
-
-  const query = `mutation { 
-      change_multiple_column_values(
-        board_id: ${mondayBoard},
-        item_id: ${mondayID},
-        column_values: "${formatValues(values)}"
-      ) {
-        id
-      }
-    }`;
-
-  const response = await callMonday(key, query);
-  if (
-    !response ||
-    !response["data"] ||
-    !response["data"]["change_multiple_column_values"]
-  ) {
-    throw new Error(`Failed to update columns for item ID ${mondayID}`);
-  }
-
-  return response["data"]["change_multiple_column_values"]["id"];
-}
-
-/**
- * Inserts or replaces the Monday sync line in the issue body string
- * @param {string | null} body - The current issue body
- * @param {string} mondayID - The Monday.com item ID
- * @returns {string} - The updated issue body
- */
-function addSyncLine(body, mondayID) {
-  const syncMarkdown = `**monday.com sync:** #${mondayID}\n\n`;
-  const syncLineRegex = /^\*\*monday\.com sync:\*\* #\d+\n\n?/m;
-  if (body && syncLineRegex.test(body)) {
-    return body.replace(syncLineRegex, syncMarkdown);
-  } else {
-    return syncMarkdown + (body || "");
-  }
-}
-
-/**
- * Assigns a label to the Monday.com task object
- * @param {string} label
- * @param {object} values - The current column values object to update
- * @returns {object} - The updated column values object
- */
-function assignLabel(label, values) {
-  if (label === "monday.com sync") {
-    // Skip the sync label, as it is not needed in Monday.com
-    return values;
-  }
-
-  if (!mondayLabels.has(label)) {
-    console.warn(`Label ${label} not found in Monday Labels map`);
-    return values;
-  }
-
-  const info = mondayLabels.get(label);
-  if (!info?.column || !info?.value) {
-    console.warn(`Label ${label} is missing column or title information`);
-    return values;
-  }
-
-  values[info.column] = info.value;
-
-  return values;
-}
-
-/**
- * Assigns a person to the Monday.com task object based on their GitHub username/role
- * @param {import('@octokit/webhooks-types').User} person
- * @param {object} values - The current column values object to update
- * @returns {object} - The updated column values object
- */
-function assignPerson(person, values) {
-  if (!person?.login) {
-    console.warn("No person or login provided for assignment");
-    return;
-  }
-
-  const info = mondayPeople.get(person.login);
-
-  if (!info) {
-    console.warn(`Assignee ${person.login} not found in peopleMap`);
-    return;
-  }
-
-  if (values[info.role]) {
-    values[info.role] += `, ${info.id}`;
-  } else {
-    values[info.role] = `${info.id}`;
-  }
-
-  return values;
-}
-
-/**
- * Checks if the labels do not include any lifecycle labels
- * @param {import('@octokit/webhooks-types').Label[] | undefined} labels - The list of labels for the issue
- * @param {object} options - Options to skip specific labels
- * @return {boolean} - True if no lifecycle labels are present, false otherwise
- */
-function notInLifecycle(labels, { skipMilestone = false } = {}) {
-  if (!labels?.length) {
-    return true;
-  }
-
-  let lifecycleLabels = Object.values(resources.labels.issueWorkflow);
-  if (skipMilestone) {
-    lifecycleLabels = lifecycleLabels.filter(
-      (label) => label !== resources.labels.issueWorkflow.needsMilestone,
-    );
-  }
-
-  return labels.every((label) => !lifecycleLabels.includes(label.name));
-}
-
-/**
- * Checks if the labels do not include the "Ready for Dev" label
- * @param {import('@octokit/webhooks-types').Label[] | undefined} labels - The list of labels for the issue
- * @return {boolean} - True if "Ready for Dev" label is not present, false otherwise
- */
-function notReadyForDev(labels) {
-  if (!labels) {
-    return true;
-  }
-
-  return labels.every(
-    (label) => label.name !== resources.labels.issueWorkflow.readyForDev,
-  );
-}
-
-/**
- * Returns column and value to update from a milestone title
- * @param {import('@octokit/webhooks-types').Milestone | null} milestone - The milestone object from the issue
- * @param {import('@octokit/webhooks-types').User | null | undefined} assignee - The assignee of the issue
- * @param {import('@octokit/webhooks-types').Label[] | undefined} labels - The list of labels for the issue
- * @returns {{ column: string, value: string }[]} - The column ID and value to update in Monday.com
- */
-function handleMilestone(milestone, assignee, labels) {
-  const resetValues = [
-    {
-      column: mondayColumns.date,
-      value: "",
-    },
-  ];
-
-  // If removed and not ready for dev, reset date
-  if (!milestone) {
-    return resetValues;
-  }
-
-  // Attempt to extract the date from the milestone title
-  const dateRegex = /\d{4}-\d{2}-\d{2}/;
-  const dueDate = milestone.title.match(dateRegex);
-
-  if (dueDate) {
-    const updates = [
-      {
-        column: mondayColumns.date,
-        value: dueDate[0],
-      },
-    ];
-
-    // Assigned and NO lifecycle label - OUTSIDE OF "needs milestone"
-    if (assignee && notInLifecycle(labels, { skipMilestone: true })) {
-      const status = mondayLabels.get(resources.labels.issueWorkflow.assigned);
-
-      if (status) {
-        updates.push({
-          column: status.column,
-          value: String(status.value),
-        });
-      }
-    }
-
-    // If unassigned and NOT "Ready for Dev"
-    if (!assignee && notReadyForDev(labels)) {
-      const status = mondayLabels.get(resources.labels.issueWorkflow.new);
-
-      if (status) {
-        updates.push({
-          column: status.column,
-          value: String(status.value),
-        });
-      }
-    }
-
-    return updates;
-  }
-
-  const statusMilestones = [
-    resources.milestone.stalled,
-    resources.milestone.backlog,
-    resources.milestone.freezer,
-  ];
-  if (statusMilestones.includes(milestone.title)) {
-    return [
-      {
-        column: mondayColumns.status,
-        value: milestone.title,
-      },
-      {
-        column: mondayColumns.date,
-        value: "",
-      },
-    ];
-  }
-
-  return [];
-}
-
-/**
- * Returns the Monday.com item ID from the issue body or fetches it based on the issue number
- * @param {string | undefined} key - The Monday.com API key
- * @param {string | null} body - The issue body containing the sync line
- * @param {number} number - The GitHub issue number
- * @return {Promise<string>} - The Monday.com item ID
- */
-async function getMondayID(key, body, number) {
-  const mondayRegex = /(?<=\*\*monday\.com sync:\*\* #)(\d+)/;
-  const mondayRegexMatch = body?.match(mondayRegex);
-  let mondayID =
-    mondayRegexMatch && mondayRegexMatch[0] ? mondayRegexMatch[0] : "";
-
-  if (!mondayID) {
-    mondayID = await fetchMondayID(key, number);
-  }
-
-  return mondayID;
-}
-
-/**
- * Creates the GraphQL query to create a new item in Monday.com
- * @param {import('@octokit/webhooks-types').Issue} issue
- * @returns {string} - The GraphQL query string
- */
-function createTaskQuery(issue) {
-  const { title, number, labels, assignee, assignees, html_url, milestone } =
-    issue;
-
-  /** @type {Record<string, string | number | object>} */
-  let values = {
-    [mondayColumns.issueNumber]: `${number}`,
-    [mondayColumns.link]: {
-      url: html_url,
-      text: `${number}`,
-    },
-  };
-
-  // Add labels if present
-  if (labels?.length) {
-    labels.forEach((label) => {
-      // TEMP: Skip "needs milestone" if "ready for dev" is applied
-      if (
-        label.name === resources.labels.issueWorkflow.needsMilestone &&
-        !notReadyForDev(labels)
-      ) {
-        console.log(
-          `Skipping '${resources.labels.issueWorkflow.needsMilestone}' label as '${resources.labels.issueWorkflow.readyForDev}' is already applied.`,
-        );
-      }
-
-      values = assignLabel(label.name, values);
-    });
-  }
-  // If no lifecycle label: set default status
-  if (notInLifecycle(labels)) {
-    const needsTriage = mondayLabels.get(
-      resources.labels.issueWorkflow.needsTriage,
-    );
-    if (needsTriage) {
-      values[needsTriage.column] = needsTriage.value;
-    }
-  }
-
-  // Add assignees if present
-  if (assignees.length) {
-    assignees.forEach((person) => {
-      values = assignPerson(person, values);
-    });
-
-    // Set to "assigned" if no lifecycle labels were applied
-    // Overrides the default "needs triage" label
-    if (notInLifecycle(labels)) {
-      const assigned = mondayLabels.get(
-        resources.labels.issueWorkflow.assigned,
-      );
-      if (assigned) {
-        values[assigned.column] = assigned.value;
-      }
-    }
-  }
-
-  // Handle milestone if present
-  if (milestone) {
-    handleMilestone(milestone, assignee, labels).forEach(
-      ({ column, value }) => {
-        values[column] = value;
-      },
-    );
-  }
-
-  const query = `mutation { 
-      create_item (
-        board_id: ${mondayBoard},
-        item_name: "${title}",
-        column_values: "${formatValues(values)}"
-      ) {
-        id
-      }
-    }`;
-
-  return query;
-}
-
-/**
- * Assignes each of the current assignees to the value object.
- * @param {import('@octokit/webhooks-types').User[]} assignees - The list of assignees from the GitHub issue
- * @param {Object} valueObject - The value object to update.
- * @returns {Object} - The updated value object with assignees added to respective columns.
- */
-function updateAssignees(assignees, valueObject) {
-  assignees.forEach((assignee) => {
-    valueObject = assignPerson(assignee, valueObject);
-  });
-  return valueObject;
-}
-
-/**
- * Formats the values object for use in Monday.com API calls
- * @param {object} values - The values object to format
- * @return {string} - The formatted values string
- */
-function formatValues(values) {
-  return JSON.stringify(values).replace(/"/g, '\\"');
-}
-
 module.exports = {
-  removeLabel,
-  createLabelIfMissing,
-  callMonday,
-  getMondayID,
-  fetchMondayID,
-  updateMultipleColumns,
-  addSyncLine,
-  assignLabel,
-  assignPerson,
-  notInLifecycle,
-  notReadyForDev,
-  handleMilestone,
-  createTaskQuery,
-  updateAssignees,
-  formatValues,
+  /**
+   * @typedef {object} removeLabelParam
+   * @property {InstanceType<typeof import('@actions/github/lib/utils').GitHub>} github
+   * @property {import('@actions/github/lib/context').Context} context
+   * @property {string} label
+   *
+   * @param {removeLabelParam} obj
+   **/
+  removeLabel: async ({ github, context, label }) => {
+    const { owner, repo } = context.repo;
+    const issue_number = context.issue.number;
+
+    try {
+      await github.rest.issues.removeLabel({
+        issue_number,
+        owner,
+        repo,
+        name: label,
+      });
+    } catch (err) {
+      if (err.status === 404) {
+        console.log(
+          `The label '${label}' is not associated with issue #${issue_number}.`,
+          err,
+        );
+      } else {
+        console.log("Error while attempting to remove issue label.", err);
+      }
+    }
+  },
+  /**
+   * @typedef {object} createLabelIfMissingParam
+   * @property {InstanceType<typeof import('@actions/github/lib/utils').GitHub>} github
+   * @property {import('@actions/github/lib/context').Context} context
+   * @property {string} label
+   * @property {string} color
+   * @property {string} description
+   *
+   * @param {createLabelIfMissingParam} obj
+   **/
+  createLabelIfMissing: async ({
+    github,
+    context,
+    label,
+    color,
+    description,
+  }) => {
+    const { owner, repo } = context.repo;
+    try {
+      await github.rest.issues.getLabel({
+        owner,
+        repo,
+        name: label,
+      });
+    } catch {
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name: label,
+        color,
+        description,
+      });
+    }
+  },
+  /**
+   * Checks if the labels do not include any lifecycle labels
+   * @param {import('@octokit/webhooks-types').Label[] | undefined} labels - The list of labels for the issue
+   * @param {object} options - Options to skip specific labels
+   * @return {boolean} - True if no lifecycle labels are present, false otherwise
+   */
+  notInLifecycle: (labels, { skipMilestone = false } = {}) => {
+    if (!labels?.length) {
+      return true;
+    }
+
+    let lifecycleLabels = Object.values(issueWorkflow);
+    if (skipMilestone) {
+      lifecycleLabels = lifecycleLabels.filter(
+        (label) => label !== issueWorkflow.needsMilestone,
+      );
+    }
+
+    return labels.every((label) => !lifecycleLabels.includes(label.name));
+  },
+  /**
+   * Checks if the labels do not include the "Ready for Dev" label
+   * @param {import('@octokit/webhooks-types').Label[] | undefined} labels - The list of labels for the issue
+   * @return {boolean} - True if "Ready for Dev" label is not present, false otherwise
+   */
+  notReadyForDev: (labels) => {
+    if (!labels) {
+      return true;
+    }
+
+    return labels.every((label) => label.name !== issueWorkflow.readyForDev);
+  },
 };


### PR DESCRIPTION
## Summary
Abstracts the Monday utility functions into a separate factory file and updates the scripts to utilize the new structure. The factory pattern reduces redundancy and creates consistency across the scripts for how values are updated and sent to Monday.com.

## Changelog
- **feat: abstract Monday utils into separate factory file**
- **refactor: update to utilize new `Monday` factory**
