### PR TITLE
fix: allow writing to PRs

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -12,6 +12,8 @@ jobs:
   refactor:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'refactor')
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6 
       - name: "Create Task"


### PR DESCRIPTION
**monday.com sync:** #12068873251

**Related Issue:** #

## Summary

Allows PR merged workflow to write to pull requests for Monday sync ID.

Should sync.
