### PR TITLE
fix: set state action for PR task creation

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -643,7 +643,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       column_values: JSON.stringify(columnUpdates),
     };
 
-    console.warn(queryVariables);
+    core.info(queryVariables);
 
     const { response, error } = await runQuery(query, queryVariables);
     if (error || !response?.data?.change_multiple_column_values) {
@@ -875,7 +875,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     }
 
     if ("merged" in issue) {
-      handleState();
+      handleState("closed");
     }
 
     const { id: syncId, source } = await getId();

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -12,6 +12,8 @@ jobs:
   refactor:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'refactor')
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6 
       - name: "Create Task"


### PR DESCRIPTION
**monday.com sync:** #12069907656

**Related Issue:** n/a

## Summary

Passes the state action for PR task creation.

Logs to core for debugging. 

Should sync.
