### PR TITLE
fix: log notice instead of info

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -643,7 +643,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       column_values: JSON.stringify(columnUpdates),
     };
 
-    core.info(queryVariables);
+    core.notice(queryVariables);
 
     const { response, error } = await runQuery(query, queryVariables);
     if (error || !response?.data?.change_multiple_column_values) {


### PR DESCRIPTION
**Related Issue:** #221

## Summary

Adjust log for debugging, testing sync.

Should not sync.
