### PR TITLE
fix: use explicit board id

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           MONDAY_KEY: ${{ secrets.MONDAY_KEY }}
-          MONDAY_BOARD: ${{ secrets.MONDAY_BOARD }}
+          MONDAY_BOARD: "8780429793"
           GITHUB_REPO: ${{ github.event.repository.name }}
         with:
           script: |


### PR DESCRIPTION
**monday.com sync:** #12070038042

**Related Issue:** #

## Summary

Was getting errors due to incorrect column IDs, just need to test using the testing board.

Should sync.
